### PR TITLE
fix: add admin API readiness probe

### DIFF
--- a/olaris-api/api-template.yaml
+++ b/olaris-api/api-template.yaml
@@ -41,6 +41,14 @@ spec:
           ports:
             - containerPort: 5000
               name: api
+          readinessProbe:
+            tcpSocket:
+              port: api
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
           env:
           - name: "APIHOST"
             value: "${SYS_API_HOSTNAME:-localhost}"


### PR DESCRIPTION
## Summary
- add a TCP readiness probe on the named admin-api port
- keep the Service endpoint unavailable until the Waitress listener is accepting connections
- make StatefulSet rollout status reflect actual application readiness

## Validation
- rendered manifest accepted by `kubectl apply --dry-run=client`
- live Kind rollout completed with the probe
- SSO password test completed successfully against the updated admin-api image