### PR TITLE
ci: pin Docker image actions by commit

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -50,17 +50,17 @@ jobs:
         run: |
           echo "IMG_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
       - name: Registry login
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: registry.hub.docker.com
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Image
         env:
           REGISTRY: apache


### PR DESCRIPTION
## Summary
Pin the Docker image workflow actions to reviewed immutable commit SHAs.

## Action pins
- `docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0` (`v4.4.0`)
- `docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8` (`v4.2.0`)
- `docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` (`v4.2.0`)

## Validation
- workflow parsed successfully as YAML
- `git diff --check`

This PR is intentionally left open.