### PR TITLE
Preinstall Python dependencies in system API image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,18 +32,24 @@ RUN useradd -m -u 1001 -s /bin/bash openserverless
 WORKDIR /home/openserverless
 
 
-# Copy source code con permessi corretti
-ADD --chown=openserverless:openserverless openserverless /home/openserverless/openserverless/
-ADD --chown=openserverless:openserverless run.sh pyproject.toml uv.lock /home/openserverless/
-
 # Install uv (Python dependency manager)
 RUN pip install --no-cache-dir uv
 
-# Install dependencies
+# Copy dependency metadata first so this layer remains cached when only source
+# code changes.
+COPY --chown=openserverless:openserverless pyproject.toml uv.lock /home/openserverless/
+
+# Resolve and download all runtime dependencies while building the image.
 USER openserverless
-RUN uv venv && uv pip install --requirement pyproject.toml
+RUN uv sync --frozen --no-dev --no-install-project \
+    && rm -rf /home/openserverless/.cache/uv
+
+# Copy source code after dependencies have been installed.
+COPY --chown=openserverless:openserverless openserverless /home/openserverless/openserverless/
+COPY --chown=openserverless:openserverless run.sh /home/openserverless/run.sh
 
 ENV HOME=/home/openserverless
+ENV PATH="/home/openserverless/.venv/bin:${PATH}"
 EXPOSE 5000
 
-CMD ["uv", "run", "-m", "openserverless"]
+CMD ["python", "-m", "openserverless"]

--- a/run.sh
+++ b/run.sh
@@ -16,4 +16,4 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-uv run -m openserverless "$@"
+exec /home/openserverless/.venv/bin/python -m openserverless "$@"


### PR DESCRIPTION
## What changed

- Installs runtime dependencies with uv sync --frozen --no-dev during the image build.
- Copies dependency metadata before application source to preserve the Docker dependency layer cache.
- Starts the service directly with the virtual-environment Python interpreter.
- Updates run.sh to avoid uv run and any runtime dependency synchronization.

## Root cause

The image previously used uv pip install against pyproject.toml during the build, then uv run at container startup. Since the build installation was not synchronized from uv.lock, uv run downloaded packages and replaced part of the environment at runtime. Pods without direct PyPI or proxy access could enter CrashLoopBackOff.

## Impact

The system API image is self-contained after docker build. A stale lock now fails the build instead of causing runtime downloads, and source-only changes can reuse the dependency layer.

## Validation

- Built the arm64 image inside the Lima VM with uv sync --frozen; 53 runtime packages were installed during build.
- Verified core imports with docker --network none.
- Loaded the image into Kind and completed the nuvolaris-system-api StatefulSet rollout.
- Confirmed PID 1 uses /home/openserverless/.venv/bin/python.
- Confirmed startup logs contain no package downloads or environment synchronization.
- Ran testing/tests/11-sso-mock.sh kind successfully, including password login, user provisioning, hello action and cleanup.

The unrelated local uv.lock modification is intentionally excluded from this PR.